### PR TITLE
Add interaural_coherence

### DIFF
--- a/.github/workflows/wordlist.txt
+++ b/.github/workflows/wordlist.txt
@@ -1,4 +1,8 @@
 AmplitudeModulation
+IAC
+iac
+narrowband
+Narrowband
 AuditoryStimuli
 auditorystimuli
 Bandpass

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -40,6 +40,11 @@ ramp_off
 ## Plotting
 
 ```@docs
-Plot
 PlotSpectroTemporal
+```
+
+## Signal Metrics
+
+```@docs
+interaural_coherence
 ```

--- a/docs/src/example-itd.md
+++ b/docs/src/example-itd.md
@@ -102,7 +102,7 @@ using Statistics
 cor(sink.buf)[2, 1]
 ```
 
-However, note that if we compute the IAC over a restrited range of lags
+However, note that if we compute the IAC over a restricted range of lags
 then we will miss the peak and thus not report the global maximum.
 By default, as above, the entire range of available lags is used.
 So if we use only a 1 ms window, whereas the itd was 1.25 ms, the IAC

--- a/src/AuditoryStimuli.jl
+++ b/src/AuditoryStimuli.jl
@@ -36,7 +36,8 @@ export  bandpass_noise,
         TimeDelay,
         samplerate,
         modify,
-        plot
+        plot,
+        interaural_coherence
 
 
 include("Plotting.jl")
@@ -59,6 +60,8 @@ include("SignalModifiers/Amplification.jl")
 include("SignalModifiers/BandpassFilter.jl")
 include("SignalModifiers/Modulation.jl")
 include("SignalModifiers/TimeDelay.jl")
+
+include("SignalMetrics/InterauralCoherence.jl")
 
 
 """

--- a/src/SignalMetrics/InterauralCoherence.jl
+++ b/src/SignalMetrics/InterauralCoherence.jl
@@ -3,23 +3,20 @@ using StatsBase
 """
     interaural_coherence(x::SampleBuf, lags::Unitful.Time)
 
-Compute the interaural coherence of two sound signals.
+Compute the interaural coherence of a two channel sound signals.
 
 Interaural coherence (IAC) is commonly defined as the 
 peak of the cross-correlation coefficient of the signals at the two ears [1, 2].
+It is commonly computed over a restricted range of `lags` of the cross-correlation function.
 
 
 Inputs
 ------
-* `x` data in the form of SampledSignals.SampleBuf.
+* `x` data in the form of SampledSignals.SampleBuf. Must be two channels of audio.
 * `lags` time range of lags to be used for finding maximum in cross correlation function.
   If lags=0, then the entire function will be used, effecively same as lags=Inf.
 
 
-TODO
-----
-
-Inf is a float not int
 
 References
 ----------
@@ -27,29 +24,38 @@ References
 1. Chait, M., Poeppel, D., de Cheveigne, A., and Simon, J.Z. (2005). Human auditory cortical processing of changes in interaural correlation. J Neurosci 25, 8518-8527.
 2. Aaronson, N.L., and Hartmann, W.M. (2010). Interaural coherence for noise bands: waveforms and envelopes. J Acoust Soc Am 127, 1367-1372.
 
+Example
+-------
+```julia
+correlation = 0.6
+source = CorrelatedNoiseSource(Float64, 48000, 2, 0.1, correlation) 
+a = read(source, 3u"s")
+@test interaural_coherence(a.data) ≈ correlation atol = 0.025
+```
 
 """
-function interaural_coherence(x::SampledSignals.SampleBuf; lags::AbstractQuantity=0u"s")
+function interaural_coherence(x::T; lags::AbstractQuantity=0u"s")::Float64 where {T<:SampledSignals.SampleBuf}
 
     lags_seconds = lags |> u"s" |> ustrip
     lags_samples = Int(lags_seconds * x.samplerate)
-    return interaural_coherence(x.data; lags=lags_samples)
+    interaural_coherence(x.data; lags=lags_samples)
 end
 
-function interaural_coherence(x::Array{T, 2}; lags::Int=0) where {T<:Number}
+function interaural_coherence(x::T; lags::AbstractQuantity=0u"s")::Float64 where {T<: DummySampleSink}
+
+    lags_seconds = lags |> u"s" |> ustrip
+    lags_samples = Int(lags_seconds * x.samplerate)
+    interaural_coherence(x.buf; lags=lags_samples)
+end
+
+function interaural_coherence(x::Array{T, 2}; lags::Int=0)::Float64 where {T<:Number}
 
     if lags == 0
-        lags = Inf
+        lags = size(x, 1) - 1
     end
 
-    if lags == Inf
-        iac = cor(x)[2, 1]
-    else
-        cc = crosscor(x[:, 1], x[:, 2], -lags:lags)
-        iac = maximum(cc)
-    end
-
-    return iac
+    cc = crosscor(x[:, 1], x[:, 2], -lags:lags)
+    iac = maximum(cc)
 end
 
 

--- a/src/SignalMetrics/InterauralCoherence.jl
+++ b/src/SignalMetrics/InterauralCoherence.jl
@@ -1,7 +1,7 @@
 using StatsBase
 
 """
-    interaural_coherence(x::Array{T, 2}, lags::Int)
+    interaural_coherence(x::SampleBuf, lags::Unitful.Time)
 
 Compute the interaural coherence of two sound signals.
 
@@ -11,8 +11,8 @@ peak of the cross-correlation coefficient of the signals at the two ears [1, 2].
 
 Inputs
 ------
-* `x` data as samples x channels.
-* `lags` number of lags to be used for finding maximum in cross correlation function (samples).
+* `x` data in the form of SampledSignals.SampleBuf.
+* `lags` time range of lags to be used for finding maximum in cross correlation function.
   If lags=0, then the entire function will be used, effecively same as lags=Inf.
 
 
@@ -25,11 +25,17 @@ References
 ----------
 
 1. Chait, M., Poeppel, D., de Cheveigne, A., and Simon, J.Z. (2005). Human auditory cortical processing of changes in interaural correlation. J Neurosci 25, 8518-8527.
-
-2.	Aaronson, N.L., and Hartmann, W.M. (2010). Interaural coherence for noise bands: waveforms and envelopes. J Acoust Soc Am 127, 1367-1372.
+2. Aaronson, N.L., and Hartmann, W.M. (2010). Interaural coherence for noise bands: waveforms and envelopes. J Acoust Soc Am 127, 1367-1372.
 
 
 """
+function interaural_coherence(x::SampledSignals.SampleBuf; lags::AbstractQuantity=0u"s")
+
+    lags_seconds = lags |> u"s" |> ustrip
+    lags_samples = Int(lags_seconds * x.samplerate)
+    return interaural_coherence(x.data; lags=lags_samples)
+end
+
 function interaural_coherence(x::Array{T, 2}; lags::Int=0) where {T<:Number}
 
     if lags == 0
@@ -45,5 +51,6 @@ function interaural_coherence(x::Array{T, 2}; lags::Int=0) where {T<:Number}
 
     return iac
 end
+
 
 

--- a/src/SignalMetrics/InterauralCoherence.jl
+++ b/src/SignalMetrics/InterauralCoherence.jl
@@ -1,0 +1,49 @@
+using StatsBase
+
+"""
+    interaural_coherence(x::Array{T, 2}, lags::Int)
+
+Compute the interaural coherence of two sound signals.
+
+Interaural coherence (IAC) is commonly defined as the 
+peak of the cross-correlation coefficient of the signals at the two ears [1, 2].
+
+
+Inputs
+------
+* `x` data as samples x channels.
+* `lags` number of lags to be used for finding maximum in cross correlation function (samples).
+  If lags=0, then the entire function will be used, effecively same as lags=Inf.
+
+
+TODO
+----
+
+Inf is a float not int
+
+References
+----------
+
+1. Chait, M., Poeppel, D., de Cheveigne, A., and Simon, J.Z. (2005). Human auditory cortical processing of changes in interaural correlation. J Neurosci 25, 8518-8527.
+
+2.	Aaronson, N.L., and Hartmann, W.M. (2010). Interaural coherence for noise bands: waveforms and envelopes. J Acoust Soc Am 127, 1367-1372.
+
+
+"""
+function interaural_coherence(x::Array{T, 2}; lags::Int=0) where {T<:Number}
+
+    if lags == 0
+        lags = Inf
+    end
+
+    if lags == Inf
+        iac = cor(x)[2, 1]
+    else
+        cc = crosscor(x[:, 1], x[:, 2], -lags:lags)
+        iac = maximum(cc)
+    end
+
+    return iac
+end
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -628,6 +628,8 @@ end
             a = read(source, 3u"s")
             @test interaural_coherence(a.data) ≈ correlation atol = 0.025
             @test interaural_coherence(a.data, lags=100) ≈ correlation atol = 0.025
+            @test interaural_coherence(a) ≈ correlation atol = 0.025
+            @test interaural_coherence(a, lags=1u"s") ≈ correlation atol = 0.025
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -323,6 +323,7 @@ end
                     a = read(source, 3u"s")
                     @test std(a) ≈ deviation atol = 0.025
                     @test cor(a.data)[2, 1] ≈ correlation atol = 0.025
+                    @test interaural_coherence(a.data) ≈ correlation atol = 0.025
                 end
             end
         end
@@ -617,3 +618,16 @@ end
     end
 end
 
+
+@testset "Signal Metrics" begin
+
+    @testset "Interaural Coherence" begin
+
+        for correlation = 0.2:0.2:0.8
+            source = CorrelatedNoiseSource(Float64, 48000, 2, 0.4, correlation)
+            a = read(source, 3u"s")
+            @test interaural_coherence(a.data) ≈ correlation atol = 0.025
+            @test interaural_coherence(a.data, lags=100) ≈ correlation atol = 0.025
+        end
+    end
+end


### PR DESCRIPTION
Add method to compute interaural coherence defined as the peak of the cross-correlation coefficent of the signals at the two ears [1, 2]. Also commonly computed over a restricted time range.

1. Chait, M., Poeppel, D., de Cheveigne, A., and Simon, J.Z. (2005). Human auditory cortical processing of changes in interaural correlation. J Neurosci 25, 8518-8527.

2.	Aaronson, N.L., and Hartmann, W.M. (2010). Interaural coherence for noise bands: waveforms and envelopes. J Acoust Soc Am 127, 1367-1372.
