### PR TITLE
Update Spellcheck action to latest version

### DIFF
--- a/.github/workflows/Spellcheck.yml
+++ b/.github/workflows/Spellcheck.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     # The checkout step
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.14.0
+    - uses: rojopolis/spellcheck-github-actions@0.24.0
       name: Spellcheck
       with:
         task_name: Markdown


### PR DESCRIPTION
I have just released 0.24.0 of the spellcheck GitHub action, I can see that you are using 0.14.0, so an update could be useful to you. Let me know if you have any issues with the proposal and I will try to accommodate.

I have recently created a [sunset policy](https://github.com/rojopolis/spellcheck-github-actions/wiki#sunset-policy) for the action and the version you are using are over a year old, so it will eventually be deleted from DockerHub.

I can recommend [Dependabot](https://github.com/dependabot) or [Renovate](https://github.com/marketplace/renovate) for keeping your GitHub actions up to date automatically, if you want a PR proposing a basic configuration, please let me know.